### PR TITLE
WHISKER-28:  Fix broken links on newly generated homepage

### DIFF
--- a/.buildtools/formatPom
+++ b/.buildtools/formatPom
@@ -1,3 +1,4 @@
+#!/bin/bash
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.

--- a/.buildtools/formatSiteXml
+++ b/.buildtools/formatSiteXml
@@ -1,3 +1,4 @@
+#!/bin/bash
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.

--- a/.buildtools/generateStagingSiteInWebpageRepo
+++ b/.buildtools/generateStagingSiteInWebpageRepo
@@ -1,3 +1,4 @@
+#!/bin/bash
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
@@ -21,38 +22,16 @@ echo "DONE."
 
 echo "Copying JS/CSS resources into generated reports"
 cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apidocs/ > /dev/null
-cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apache-whisker-velocity/apidocs/ > /dev/null
-cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apache-whisker-app/apidocs/ > /dev/null
-cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apache-whisker-xml/apidocs/ > /dev/null
-cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apache-whisker-scan/apidocs/ > /dev/null
-cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apache-whisker-model/apidocs/ > /dev/null
-cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apache-whisker-maven-plugin/apidocs/ > /dev/null
-cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apache-whisker-cli/apidocs/ > /dev/null
-
 cp -rvf src/site/javadocFont/* ../creadur-site/whisker/testapidocs/ > /dev/null
-cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apache-whisker-velocity/testapidocs/ > /dev/null
-cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apache-whisker-app/testapidocs/ > /dev/null
-cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apache-whisker-xml/testapidocs/ > /dev/null
-cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apache-whisker-scan/testapidocs/ > /dev/null
-cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apache-whisker-model/testapidocs/ > /dev/null
-cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apache-whisker-maven-plugin/testapidocs/ > /dev/null
-cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apache-whisker-cli/testapidocs/ > /dev/null
-
 cp -rvf src/site/javadocFont/* ../creadur-site/whisker/xref/ > /dev/null
-cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apache-whisker-velocity/xref/ > /dev/null
-cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apache-whisker-app/xref/ > /dev/null
-cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apache-whisker-xml/xref/ > /dev/null
-cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apache-whisker-scan/xref/ > /dev/null
-cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apache-whisker-model/xref/ > /dev/null
-cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apache-whisker-maven-plugin/xref/ > /dev/null
-cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apache-whisker-cli/xref/ > /dev/null
-
 cp -rvf src/site/javadocFont/* ../creadur-site/whisker/xref-test/ > /dev/null
-cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apache-whisker-velocity/xref-test/ > /dev/null
-cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apache-whisker-app/xref-test/ > /dev/null
-cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apache-whisker-xml/xref-test/ > /dev/null
-cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apache-whisker-scan/xref-test/ > /dev/null
-cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apache-whisker-model/xref-test/ > /dev/null
-cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apache-whisker-maven-plugin/xref-test/ > /dev/null
-cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apache-whisker-cli/xref-test/ > /dev/null
+
+for module in "apache-whisker-velocity" "apache-whisker-app" "apache-whisker-xml" "apache-whisker-scan" "apache-whisker-model" "apache-whisker-maven-plugin" "apache-whisker-cli"
+ do
+  cp -rvf src/site/javadocFont/* ../creadur-site/whisker/$module/apidocs/ > /dev/null
+  cp -rvf src/site/javadocFont/* ../creadur-site/whisker/$module/testapidocs/ > /dev/null
+  cp -rvf src/site/javadocFont/* ../creadur-site/whisker/$module/xref/ > /dev/null
+  cp -rvf src/site/javadocFont/* ../creadur-site/whisker/$module/xref-test/ > /dev/null
+ done
+
 echo "DONE."

--- a/.buildtools/generateStagingSiteInWebpageRepo
+++ b/.buildtools/generateStagingSiteInWebpageRepo
@@ -14,9 +14,43 @@
 # limitations under the License.
 #
 ./mvnw clean site:site site:stage
+
+echo "Copying site resources into asf-site repo"
 cp -rvf target/staging/* ../creadur-site/whisker/
+
 echo "Copying JS/CSS resources into generated reports"
 cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apidocs/
+cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apache-whisker-verlocity/apidocs/
+cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apache-whisker-app/apidocs/
+cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apache-whisker-xml/apidocs/
+cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apache-whisker-scan/apidocs/
+cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apache-whisker-model/apidocs/
+cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apache-whisker-maven-plugin/apidocs/
+cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apache-whisker-cli/apidocs/
+
 cp -rvf src/site/javadocFont/* ../creadur-site/whisker/testapidocs/
+cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apache-whisker-verlocity/testapidocs/
+cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apache-whisker-app/testapidocs/
+cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apache-whisker-xml/testapidocs/
+cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apache-whisker-scan/testapidocs/
+cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apache-whisker-model/testapidocs/
+cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apache-whisker-maven-plugin/testapidocs/
+cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apache-whisker-cli/testapidocs/
+
 cp -rvf src/site/javadocFont/* ../creadur-site/whisker/xref/
+cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apache-whisker-velocity/xref/
+cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apache-whisker-app/xref/
+cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apache-whisker-xml/xref/
+cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apache-whisker-scan/xref/
+cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apache-whisker-model/xref/
+cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apache-whisker-maven-plugin/xref/
+cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apache-whisker-cli/xref/
+
 cp -rvf src/site/javadocFont/* ../creadur-site/whisker/xref-test/
+cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apache-whisker-velocity/xref-test/
+cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apache-whisker-app/xref-test/
+cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apache-whisker-xml/xref-test/
+cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apache-whisker-scan/xref-test/
+cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apache-whisker-model/xref-test/
+cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apache-whisker-maven-plugin/xref-test/
+cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apache-whisker-cli/xref-test/

--- a/.buildtools/generateStagingSiteInWebpageRepo
+++ b/.buildtools/generateStagingSiteInWebpageRepo
@@ -15,5 +15,8 @@
 #
 ./mvnw clean site:site site:stage
 cp -rvf target/staging/* ../creadur-site/whisker/
+echo "Copying JS/CSS resources into generated reports"
 cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apidocs/
 cp -rvf src/site/javadocFont/* ../creadur-site/whisker/testapidocs/
+cp -rvf src/site/javadocFont/* ../creadur-site/whisker/xref/
+cp -rvf src/site/javadocFont/* ../creadur-site/whisker/xref-test/

--- a/.buildtools/generateStagingSiteInWebpageRepo
+++ b/.buildtools/generateStagingSiteInWebpageRepo
@@ -16,41 +16,43 @@
 ./mvnw clean site:site site:stage
 
 echo "Copying site resources into asf-site repo"
-cp -rvf target/staging/* ../creadur-site/whisker/
+cp -rvf target/staging/* ../creadur-site/whisker/ > /dev/null
+echo "DONE."
 
 echo "Copying JS/CSS resources into generated reports"
-cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apidocs/
-cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apache-whisker-verlocity/apidocs/
-cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apache-whisker-app/apidocs/
-cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apache-whisker-xml/apidocs/
-cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apache-whisker-scan/apidocs/
-cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apache-whisker-model/apidocs/
-cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apache-whisker-maven-plugin/apidocs/
-cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apache-whisker-cli/apidocs/
+cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apidocs/ > /dev/null
+cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apache-whisker-velocity/apidocs/ > /dev/null
+cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apache-whisker-app/apidocs/ > /dev/null
+cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apache-whisker-xml/apidocs/ > /dev/null
+cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apache-whisker-scan/apidocs/ > /dev/null
+cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apache-whisker-model/apidocs/ > /dev/null
+cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apache-whisker-maven-plugin/apidocs/ > /dev/null
+cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apache-whisker-cli/apidocs/ > /dev/null
 
-cp -rvf src/site/javadocFont/* ../creadur-site/whisker/testapidocs/
-cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apache-whisker-verlocity/testapidocs/
-cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apache-whisker-app/testapidocs/
-cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apache-whisker-xml/testapidocs/
-cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apache-whisker-scan/testapidocs/
-cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apache-whisker-model/testapidocs/
-cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apache-whisker-maven-plugin/testapidocs/
-cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apache-whisker-cli/testapidocs/
+cp -rvf src/site/javadocFont/* ../creadur-site/whisker/testapidocs/ > /dev/null
+cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apache-whisker-velocity/testapidocs/ > /dev/null
+cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apache-whisker-app/testapidocs/ > /dev/null
+cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apache-whisker-xml/testapidocs/ > /dev/null
+cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apache-whisker-scan/testapidocs/ > /dev/null
+cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apache-whisker-model/testapidocs/ > /dev/null
+cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apache-whisker-maven-plugin/testapidocs/ > /dev/null
+cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apache-whisker-cli/testapidocs/ > /dev/null
 
-cp -rvf src/site/javadocFont/* ../creadur-site/whisker/xref/
-cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apache-whisker-velocity/xref/
-cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apache-whisker-app/xref/
-cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apache-whisker-xml/xref/
-cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apache-whisker-scan/xref/
-cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apache-whisker-model/xref/
-cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apache-whisker-maven-plugin/xref/
-cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apache-whisker-cli/xref/
+cp -rvf src/site/javadocFont/* ../creadur-site/whisker/xref/ > /dev/null
+cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apache-whisker-velocity/xref/ > /dev/null
+cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apache-whisker-app/xref/ > /dev/null
+cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apache-whisker-xml/xref/ > /dev/null
+cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apache-whisker-scan/xref/ > /dev/null
+cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apache-whisker-model/xref/ > /dev/null
+cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apache-whisker-maven-plugin/xref/ > /dev/null
+cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apache-whisker-cli/xref/ > /dev/null
 
-cp -rvf src/site/javadocFont/* ../creadur-site/whisker/xref-test/
-cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apache-whisker-velocity/xref-test/
-cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apache-whisker-app/xref-test/
-cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apache-whisker-xml/xref-test/
-cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apache-whisker-scan/xref-test/
-cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apache-whisker-model/xref-test/
-cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apache-whisker-maven-plugin/xref-test/
-cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apache-whisker-cli/xref-test/
+cp -rvf src/site/javadocFont/* ../creadur-site/whisker/xref-test/ > /dev/null
+cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apache-whisker-velocity/xref-test/ > /dev/null
+cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apache-whisker-app/xref-test/ > /dev/null
+cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apache-whisker-xml/xref-test/ > /dev/null
+cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apache-whisker-scan/xref-test/ > /dev/null
+cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apache-whisker-model/xref-test/ > /dev/null
+cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apache-whisker-maven-plugin/xref-test/ > /dev/null
+cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apache-whisker-cli/xref-test/ > /dev/null
+echo "DONE."

--- a/.buildtools/generateStagingSiteInWebpageRepo
+++ b/.buildtools/generateStagingSiteInWebpageRepo
@@ -16,3 +16,4 @@
 ./mvnw clean site:site site:stage
 cp -rvf target/staging/* ../creadur-site/whisker/
 cp -rvf src/site/javadocFont/* ../creadur-site/whisker/apidocs/
+cp -rvf src/site/javadocFont/* ../creadur-site/whisker/testapidocs/

--- a/apache-whisker-maven-plugin/src/site/apt/index.apt.vm
+++ b/apache-whisker-maven-plugin/src/site/apt/index.apt.vm
@@ -60,7 +60,7 @@ useful not only for building components but also for assembling them into applic
   entire debug logs, POMs or most preferably little demo projects attached to the issue are very much appreciated.
   
   Of course, patches are very welcome, too. Contributors can check out the project from our
-  {{{./source-repository.html}source repository}}. Apache Whisker is developed collaboratively
+  {{{./scm.html}source repository}}. Apache Whisker is developed collaboratively
   by the {{{http://creadur.apache.org}Apache Creadur}} {{{http://community.apache.org/}community}}.
   We create and maintain a range of {{{http://www.opensource.org}open source}} software tools
   which assist in the audit, review and comprehension of software distributions. Please 

--- a/apache-whisker-maven-plugin/src/site/apt/index.apt.vm
+++ b/apache-whisker-maven-plugin/src/site/apt/index.apt.vm
@@ -55,7 +55,7 @@ useful not only for building components but also for assembling them into applic
   the {{{./mailing-lists.html}mail archive}}.
 
   If you feel like the plugin is missing a feature or has a defect, you can fill a feature request or bug report in our
-  {{{./issue-tracking.html}issue tracker}}. When creating a new issue, please provide a comprehensive description of your
+  {{{./issue-management.html}issue tracker}}. When creating a new issue, please provide a comprehensive description of your
   concern. Especially for fixing bugs it is crucial that the developers can reproduce your problem. For this reason,
   entire debug logs, POMs or most preferably little demo projects attached to the issue are very much appreciated.
   

--- a/apache-whisker-maven-plugin/src/site/apt/index.apt.vm
+++ b/apache-whisker-maven-plugin/src/site/apt/index.apt.vm
@@ -61,8 +61,8 @@ useful not only for building components but also for assembling them into applic
   
   Of course, patches are very welcome, too. Contributors can check out the project from our
   {{{./scm.html}source repository}}. Apache Whisker is developed collaboratively
-  by the {{{http://creadur.apache.org}Apache Creadur}} {{{http://community.apache.org/}community}}.
-  We create and maintain a range of {{{http://www.opensource.org}open source}} software tools
+  by the {{{https://creadur.apache.org}Apache Creadur}} {{{https://community.apache.org/}community}}.
+  We create and maintain a range of {{{https://www.opensource.org}open source}} software tools
   which assist in the audit, review and comprehension of software distributions. Please 
   {{{./mailing-lists.html}drop in and say hello}}.
     

--- a/apache-whisker-maven-plugin/src/site/apt/index.apt.vm
+++ b/apache-whisker-maven-plugin/src/site/apt/index.apt.vm
@@ -50,9 +50,9 @@ useful not only for building components but also for assembling them into applic
   specific use cases are described in the examples given below. 
   
   In case you still have questions regarding the plugin's usage, please have a look at the {{{./faq.html}FAQ}} and feel
-  free to contact the {{{./mail-lists.html}mailing list}}. The posts to the mailing list are archived and could
+  free to contact the {{{./mailing-lists.html}mailing list}}. The posts to the mailing list are archived and could
   already contain the answer to your question as part of an older thread. Hence, it is also worth browsing/searching
-  the {{{./mail-lists.html}mail archive}}.
+  the {{{./mailing-lists.html}mail archive}}.
 
   If you feel like the plugin is missing a feature or has a defect, you can fill a feature request or bug report in our
   {{{./issue-tracking.html}issue tracker}}. When creating a new issue, please provide a comprehensive description of your
@@ -64,7 +64,7 @@ useful not only for building components but also for assembling them into applic
   by the {{{http://creadur.apache.org}Apache Creadur}} {{{http://community.apache.org/}community}}.
   We create and maintain a range of {{{http://www.opensource.org}open source}} software tools
   which assist in the audit, review and comprehension of software distributions. Please 
-  {{{./mail-lists.html}drop in and say hello}}.
+  {{{./mailing-lists.html}drop in and say hello}}.
     
 
 * Examples

--- a/apache-whisker-maven-plugin/src/site/fml/faq.fml
+++ b/apache-whisker-maven-plugin/src/site/fml/faq.fml
@@ -29,7 +29,7 @@
         spare a few cycles to 
         <a href='https://www.apache.org/foundation/getinvolved.html'>help development</a>, that'd be
         greatly appreciated. Take a look at the 
-        <a href='source-repository.html'>source</a> 
+        <a href='scm.html'>source</a>
         then please join us on our
         <a href='./mailing-lists.html'>mail lists</a>
         or open a <a href='./issue-management.html'>issue</a>.</p>

--- a/apache-whisker-maven-plugin/src/site/fml/faq.fml
+++ b/apache-whisker-maven-plugin/src/site/fml/faq.fml
@@ -32,7 +32,7 @@
         <a href='source-repository.html'>source</a> 
         then please join us on our
         <a href='./mailing-lists.html'>mail lists</a>
-        or open a <a href='./issue-tracking.html'>issue</a>.</p>
+        or open a <a href='./issue-management.html'>issue</a>.</p>
       </answer>
     </faq>
   </part>

--- a/pom.xml
+++ b/pom.xml
@@ -507,4 +507,27 @@
     <developerConnection>scm:git:https://gitbox.apache.org/repos/asf/creadur-whisker.git</developerConnection>
     <url>https://gitbox.apache.org/repos/asf?p=creadur-whisker.git</url>
   </scm>
+  <developers>
+    <developer>
+      <id>rdonkin</id>
+      <name>Robert Burrell Donkin</name>
+      <email>rdonkin@apache.org</email>
+    </developer>
+    <developer>
+      <id>dennisl</id>
+      <name>Dennis Lundberg</name>
+      <email>dennisl@apache.org</email>
+    </developer>
+    <developer>
+      <id>pottlinger</id>
+      <name>Philipp Ottlinger</name>
+      <email>pottlinger@apache.org</email>
+    </developer>
+  </developers>
+  <contributors>
+    <contributor>
+      <name>sebbASF</name>
+      <email>sebb@apache.org</email>
+    </contributor>
+  </contributors>
 </project>

--- a/src/site/apt/examples/3rd-party-corporate.apt
+++ b/src/site/apt/examples/3rd-party-corporate.apt
@@ -86,7 +86,7 @@ With A Corporate Third Party Work
 
  If you have
   any questions, please try the {{{../faq.html}FAQ}} before asking on the
-  {{{../mail-lists.html}mail lists}}.
+  {{{../mailing-lists.html}mail lists}}.
 
 * The Story So Far
 

--- a/src/site/apt/examples/3rd-party-group.apt
+++ b/src/site/apt/examples/3rd-party-group.apt
@@ -87,7 +87,7 @@ With A Third Party Work by an Informal Group
 
  If you have
   any questions, please try the {{{../faq.html}FAQ}} before asking on the
-  {{{../mail-lists.html}mail lists}}.
+  {{{../mailing-lists.html}mail lists}}.
 
 * The Story So Far
 

--- a/src/site/apt/examples/3rd-party-individual.apt
+++ b/src/site/apt/examples/3rd-party-individual.apt
@@ -86,7 +86,7 @@ With An Individual Third Party Work
 
  If you have
   any questions, please try the {{{../faq.html}FAQ}} before asking on the
-  {{{../mail-lists.html}mail lists}}.
+  {{{../mailing-lists.html}mail lists}}.
 
 * The Story So Far
 

--- a/src/site/apt/examples/copyright-notices.apt
+++ b/src/site/apt/examples/copyright-notices.apt
@@ -87,7 +87,7 @@ All About Copyright Notices
 
  If you have
   any questions, please try the {{{../faq.html}FAQ}} before asking on the
-  {{{../mail-lists.html}mail lists}}.
+  {{{../mailing-lists.html}mail lists}}.
 
 * Licenses, Claims and Copyright Notices
 

--- a/src/site/apt/examples/in-5-mins.apt
+++ b/src/site/apt/examples/in-5-mins.apt
@@ -85,7 +85,7 @@ Whisker In 5 Minutes
 
  If you have
   any questions, please try the {{{../faq.html}FAQ}} before asking on the
-  {{{../mail-lists.html}mail lists}}.
+  {{{../mailing-lists.html}mail lists}}.
 
 * Basic Structure
 

--- a/src/site/apt/examples/license-family.apt
+++ b/src/site/apt/examples/license-family.apt
@@ -85,7 +85,7 @@ Parameterising a Template for a License Family
 
  If you have
   any questions, please try the {{{../faq.html}FAQ}} before asking on the
-  {{{../mail-lists.html}mail lists}}.
+  {{{../mailing-lists.html}mail lists}}.
 
 * The Story So Far
 

--- a/src/site/apt/index.apt
+++ b/src/site/apt/index.apt
@@ -108,7 +108,7 @@ What Is Apache Whisker&#8482;?
  or browse the {{{./faq.html}FAQ}}.
 
  A warm welcome is guaranteed on our
- {{{../mailing-lists.html}mail lists}}.
+ {{{./mailing-lists.html}mail lists}}.
 
 ** More Examples
 

--- a/src/site/fml/faq.fml
+++ b/src/site/fml/faq.fml
@@ -308,7 +308,7 @@ If it were, probably a language like
             <p>
 There are currently no known plugins. If you know of a plugin please
 <a href='./mailing-lists.html'>let us know</a> or
-<a href='./source-repository.html'>contribute a patch</a> for this documentation.
+<a href='./scm.html'>contribute a patch</a> for this documentation.
             </p>
         </answer>
     </faq>

--- a/src/site/fml/faq.fml
+++ b/src/site/fml/faq.fml
@@ -639,7 +639,7 @@ an informal <a href='./examples/3rd-party-group-sample.xml'>group</a>
       </ul>
       <p>If you have a use case where an unnecessary <code>NOTICE</code> is generated,
       or when a <code>NOTICE</code> isn't generated when it is needed please open an
-      <a href='./issue-tracking.html'>issue</a> or let us know
+      <a href='./issue-management.html'>issue</a> or let us know
       <a href='./mailing-lists.html'>on list</a>.</p>
       </answer>
     </faq>

--- a/src/site/fml/faq.fml
+++ b/src/site/fml/faq.fml
@@ -307,7 +307,7 @@ If it were, probably a language like
             </p>
             <p>
 There are currently no known plugins. If you know of a plugin please
-<a href='./mail-lists.html'>let us know</a> or
+<a href='./mailing-lists.html'>let us know</a> or
 <a href='./source-repository.html'>contribute a patch</a> for this documentation.
             </p>
         </answer>
@@ -640,7 +640,7 @@ an informal <a href='./examples/3rd-party-group-sample.xml'>group</a>
       <p>If you have a use case where an unnecessary <code>NOTICE</code> is generated,
       or when a <code>NOTICE</code> isn't generated when it is needed please open an
       <a href='./issue-tracking.html'>issue</a> or let us know
-      <a href='./mail-lists.html'>on list</a>.</p>
+      <a href='./mailing-lists.html'>on list</a>.</p>
       </answer>
     </faq>
     <faq id="when-source-links">


### PR DESCRIPTION
After WHISKER-26 is merged into master,
cleanup site repo and fix remaining errors.

Verify via:
`$ linkchecker https://creadur.apache.org/whisker
`

* Javadoc CSS and JS are missing in all submodules of a project
* linkchecker logs checked in as https://github.com/apache/creadur-site/commit/2a6a3f51d027a98b7ae77c127cf9196994c88773
